### PR TITLE
Update for vue 2.0

### DIFF
--- a/VueCropper.js
+++ b/VueCropper.js
@@ -4,24 +4,26 @@ var Cropper = require('cropperjs').default;
 require('cropperjs/dist/cropper.css');
 
 var CropperComponent = Vue.extend({
-    template: `
-        <div :style="style">
-            <img
-                v-el:img
-                :src="src"
-                :alt="[ alt === undefined ? 'image': alt ]"
-                style="max-width: 100%;"
-                :style="imgStyle"
-            />
-        </div>
-    `,
+    render: function (h) {
+      return h('div', {style: this.style}, [
+        h('img', {
+          ref: 'img',
+          attrs: {
+            src: this.src,
+            alt: this.alt || 'image',
+            style: {'max-width': '100%'},
+          },
+          style: this.imgStyle
+        })
+      ])
+    },
     props: {
         'style': Object,
         'data': Object,
         'preview': String,
         'src': {
             type: String,
-            required: true
+            default: ''
         },
         'alt': String,
         'imgStyle': String,
@@ -116,14 +118,14 @@ var CropperComponent = Vue.extend({
         'minContainerHeight': Number,
 
         // callbacks
-        'ready': Function,
-        'cropstart': Function,
-        'cropmove': Function,
-        'cropend': Function,
-        'crop': Function,
-        'zoom': Function,
+        // 'ready': Function,
+        // 'cropstart': Function,
+        // 'cropmove': Function,
+        // 'cropend': Function,
+        // 'crop': Function,
+        // 'zoom': Function,
     },
-    ready () {
+    mounted: function () {
         var data = omit(this.$options.props, ['style', 'src', 'alt', 'imgStyle']);
         var props = {};
         for (var key in data) {
@@ -132,7 +134,7 @@ var CropperComponent = Vue.extend({
             }
         }
 
-        this.cropper = new Cropper(this.$els.img, props);
+        this.cropper = new Cropper(this.$refs.img, props);
     },
     methods: {
         reset () {

--- a/VueCropper.js
+++ b/VueCropper.js
@@ -10,7 +10,7 @@ var CropperComponent = Vue.extend({
           ref: 'img',
           attrs: {
             src: this.src,
-            alt: `[${this.alt === undefined ? 'image' : this.alt}]`,
+            alt: '[' + this.alt === undefined ? 'image' : this.alt + ']',
             style: {'max-width': '100%'},
           },
           style: this.imgStyle

--- a/VueCropper.js
+++ b/VueCropper.js
@@ -11,7 +11,7 @@ var CropperComponent = Vue.extend({
           attrs: {
             src: this.src,
             alt: '[' + this.alt === undefined ? 'image' : this.alt + ']',
-            style: {'max-width': '100%'},
+            style: 'max-width: 100%',
           },
           style: this.imgStyle
         })

--- a/VueCropper.js
+++ b/VueCropper.js
@@ -10,7 +10,7 @@ var CropperComponent = Vue.extend({
           ref: 'img',
           attrs: {
             src: this.src,
-            alt: '[' + this.alt === undefined ? 'image' : this.alt + ']',
+            alt: '[' + (this.alt === undefined ? 'image' : this.alt) + ']',
             style: 'max-width: 100%',
           },
           style: this.imgStyle

--- a/VueCropper.js
+++ b/VueCropper.js
@@ -10,7 +10,7 @@ var CropperComponent = Vue.extend({
           ref: 'img',
           attrs: {
             src: this.src,
-            alt: this.alt || 'image',
+            alt: `[${this.alt === undefined ? 'image' : this.alt}]`,
             style: {'max-width': '100%'},
           },
           style: this.imgStyle

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "cropperjs": "~0.8.x"
   },
   "peerDependencies": {
-    "vue": "^1.0.26"
+    "vue": "^2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cropperjs",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "A Vue wrapper component for cropperjs",
   "main": "VueCropper.js",
   "keywords": [


### PR DESCRIPTION
Swap out `template` for `render` and `$els` for `$refs`.

Also switched the src to default to an empty string since it's not required by cropper and it's better to use `replace` to change the image.

I was also getting warning for the function props so I just commented them out for now, maybe someone else can take a look at that?