### PR TITLE
Fix wrong package name when requiring lodash dependency

### DIFF
--- a/VueCropper.js
+++ b/VueCropper.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Vue = require('vue');
-var omit = require('lodash/omit');
+var omit = require('lodash.omit');
 var Cropper = require('cropperjs').default;
 require('cropperjs/dist/cropper.css');
 


### PR DESCRIPTION
The right name is 'lodash.omit' but it's being required as 'lodash/omit'.