### PR TITLE
Fixed img style definition

### DIFF
--- a/VueCropper.js
+++ b/VueCropper.js
@@ -27,7 +27,7 @@ var CropperComponent = Vue.extend({
             default: ''
         },
         'alt': String,
-        'imgStyle': String,
+        'imgStyle': Object,
         'dragMode': String,
         'responsive': {
             type: Boolean,

--- a/VueCropper.js
+++ b/VueCropper.js
@@ -12,10 +12,9 @@ var CropperComponent = Vue.extend({
                 ref: 'img',
                 attrs: {
                     src: this.src,
-                    alt: this.alt || 'image',
-                    style: { 'max-width': '100%' }
+                    alt: this.alt || 'image'
                 },
-                style: this.imgStyle
+                style: this.imgStyle || { 'max-width': '100%' }
             })
         ]);
     },


### PR DESCRIPTION
At the moment, imgStyle is defined as a `style` attribute within `attrs` field inside VueCropper render function which causes rendering img style as `[object Object]` as demonstrated in the picture:
![object](https://cloud.githubusercontent.com/assets/6930479/22336423/83d45cec-e3e2-11e6-961f-ef252c242c46.png)

This causes some unpredictable behaviour with the cropper.js lib. In my case, it caused the library to wrongly calculate the height of `cropper-container` div.

According to the Vue documentation, `style` as a top-level field can be defined as an object. However, if defined through `attrs` field, it should be a string instead. E.g.
```javascript
attrs: {
  style: 'max-width: 100%'
}
```

This patch changes the above explained behaviour and defines style as a top-level field. It receives `imgStyle` prop if one is defined or defaults to `{ 'max-width': '100px' }`. Example of the fixed behaviour can be seen in the picture below:
![fixed](https://cloud.githubusercontent.com/assets/6930479/22336432/8d33fcfc-e3e2-11e6-9da3-d311cc6adcbb.png)
