### PR TITLE
Add support for crop() method

### DIFF
--- a/VueCropper.js
+++ b/VueCropper.js
@@ -150,6 +150,11 @@ const CropperComponent = Vue.extend({
             return this.cropper.clear();
         },
 
+        // Init crop box manually
+        initCrop() {
+            return this.cropper.crop();
+        },
+
         /**
          * Replace the image's src and rebuild the cropper
          * @param {string} url - The new URL.

--- a/dist/VueCropper.js
+++ b/dist/VueCropper.js
@@ -164,6 +164,9 @@ var CropperComponent = _vue2.default.extend({
         clear: function clear() {
             return this.cropper.clear();
         },
+        initCrop: function initCrop() {
+            return this.cropper.crop();
+        },
         replace: function replace(url) {
             var onlyColorChanged = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 


### PR DESCRIPTION
Hi,

Cropperjs provides a crop() method that isn't implemented in your Vue wrapper.

I added support for it by renaming the original crop() method into initCrop() (since crop() was already used as a prop for the crop event).

Thank you for your great job, this wrapper is really helpful ;)

