### PR TITLE
Fix example page when using IE11

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -26,6 +26,7 @@
     "css-loader": "^0.26.1",
     "file-loader": "^0.10.0",
     "html-webpack-plugin": "^2.28.0",
+    "string.prototype.includes": "^1.0.0",
     "style-loader": "^0.13.1",
     "vue-hot-reload-api": "^1.2.0",
     "vue-html-loader": "^1.0.0",

--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -35,6 +35,7 @@
 
 <script>
   import VueCropper from 'vue-cropperjs';
+  import { includes } from "string.prototype.includes";
 
 
   export default {


### PR DESCRIPTION
When attempting to run the example in IE11, it will throw an error on the upload because IE11 doesn't support includes. 

Added polyfill to fix this issue in IE11.