### PR TITLE
Listening to events with the normal way.

### DIFF
--- a/VueCropper.js
+++ b/VueCropper.js
@@ -121,18 +121,14 @@ export default {
     minCropBoxHeight: Number,
     minContainerWidth: Number,
     minContainerHeight: Number,
-
-    // callbacks
-    ready: Function,
-    cropstart: Function,
-    cropmove: Function,
-    cropend: Function,
-    crop: Function,
-    zoom: Function
   },
   mounted() {
     const { containerStyle, src, alt, imgStyle, ...data } = this.$options.props
     const props = {}
+
+    for (var event in this.$listeners) {
+      props[event] = this.$listeners[event]
+    }
 
     for (const key in data) {
       if (this[key] !== undefined) {


### PR DESCRIPTION
Make listening to events working with the normal behavior instead of passing events as props.
I wanted to do the following to prevent passing invalid methods (events) to the Cropper but I think it doesn't worth and it is not a good idea, so I'll leave it for you to decide.

```javascript
for (var event in this.$listeners) {
  // if (['ready', 'cropstart', 'cropmove', 'cropend', 'crop', 'zoom'].indexOf(event) > -1) {
    props[event] = this.$listeners[event]
  // } else {
    // console.warn(`The ${event} is not an event`)
  // }
}
```

Of course, we can now do so.
```vue
<vue-cropper
  @ready="cropperReay"
  @zoom="zooming"
  @crop="cropping">
</vue-cropper>
```