### PR TITLE
Add example how to use containerStyle option to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ See cropperjs [documentation](https://github.com/fengyuanchen/cropperjs#options)
 - `relativeZoom` from `zoom`
 - `initCrop` from `crop`
 
+## FAQ
+> How to set container height ?
+- You can set height in containerStyle option. Example: `<vue-cropper ref="cropper" containerStyle="max-height:60vh" />`
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ See cropperjs [documentation](https://github.com/fengyuanchen/cropperjs#options)
 
 ## FAQ
 > How to set container height ?
-- You can set height in containerStyle option. Example: `<vue-cropper ref="cropper" containerStyle="max-height:60vh" />`
+- You can set height in containerStyle option. Example: `<vue-cropper ref="cropper" :containerStyle="{'max-height':'60vh'}" />`
 
 ## License
 


### PR DESCRIPTION
I think it's useful to see small examples of custom properties instead of trying to find it in closed issues.